### PR TITLE
Add gui colors for Normal highlight group.

### DIFF
--- a/colors/noirblaze.vim
+++ b/colors/noirblaze.vim
@@ -33,6 +33,7 @@ syntax reset
 let g:colors_name = "noirblaze"
 
 exec "hi Normal ctermfg=".cterm_gray_400." ctermbg=".cterm_gray_900
+exec "hi Normal guifg=".gray_400." guibg=".gray_900
 
 " Default
 exec "hi Comment guifg=".gray_700


### PR DESCRIPTION
Hi, I just found that adding the guifg/bg colors to the Normal group fixed some highlighting issues I came across with another plugin (Goyo). The lack of gui color setting is also apparent when using `:highlight` in gvim, for example (the background changes to a white). It wasn't apparent to me if they were omitted for a reason; if so, not a problem.